### PR TITLE
Handle Error related to using the "demo" API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ After obtaining an API Key, create a new file in this repository called ".env", 
 
 Don't worry, the ".env" has already been [ignored](/.gitignore) from version control for you!
 
-> NOTE: this app will try to use a "demo" API key if this environment variables is not configured.
-
 ## Usage
 
 Run the recommendation script:

--- a/app/robo_advisor.py
+++ b/app/robo_advisor.py
@@ -10,7 +10,7 @@ import requests
 
 load_dotenv() #> loads contents of the .env file into the script's environment
 
-API_KEY = os.environ.get("ALPHAVANTAGE_API_KEY", "demo") # default to using the "demo" key if an Env Var is not supplied
+API_KEY = os.environ.get("ALPHAVANTAGE_API_KEY")
 
 def get_response(symbol):
     request_url = f"https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol={symbol}&apikey={API_KEY}"

--- a/app/robo_advisor.py
+++ b/app/robo_advisor.py
@@ -10,7 +10,7 @@ import requests
 
 load_dotenv() #> loads contents of the .env file into the script's environment
 
-API_KEY = os.environ.get("ALPHAVANTAGE_API_KEY")
+API_KEY = os.environ.get("ALPHAVANTAGE_API_KEY", "abc123") # default to using this example API Key, which is surprisingly valid :-D
 
 def get_response(symbol):
     request_url = f"https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol={symbol}&apikey={API_KEY}"


### PR DESCRIPTION
We noticed that the program crashes when it uses "demo" as the API Key. From my memory, it had previously been OK to use the "demo" API Key programmatically and the API wouldn't restrict access, but perhaps the AlphaVantage API changed its behavior. Now the normal browser message is returned:

```py
{'Information': 'The **demo** API key is for demo purposes only. Please claim your free API key at (https://www.alphavantage.co/support/#api-key) to explore our full API offerings. It takes fewer than 20 seconds, and we are committed to making it free forever.'}
```

So the program either needs to not default to using the "demo" API Key, or the program should gracefully handle errors resulting from using this key.

The way to handle the error would be something like the following:

```py
    if "Information" in parsed_response.keys() and "Please claim your free API key" in parsed_response["Information"]:
        # HANDLE A RESPONSE ERROR DUE TO MISSING API KEY
        print(parsed_response["Information"])
        exit()
```

But an easier and simpler solution is to just default to not specifying an API Key. In theory this would result in a runtime error as well, but the `None` value is actually converted to a string `"None"` when concatenated into the request URL, and this is surprisingly a valid API Key.

I guess another, better solution would be to use "abc123" (another surprisingly valid API Key) as the default value.